### PR TITLE
Fix empty text in zeroWidthToBinary and binaryToZeroWidth to \uFEFF

### DIFF
--- a/src/utils/usernameToZeroWidth.js
+++ b/src/utils/usernameToZeroWidth.js
@@ -13,7 +13,7 @@ const binaryToZeroWidth = binary => (
       return '‌'; // invisible &#8204;
     }
     return '‍'; // invisible &#8205;
-  }).join('') // invisible &#65279;
+  }).join('﻿') // invisible &#65279;
 );
 
 export default (username) => {

--- a/src/utils/zeroWidthToUsername.js
+++ b/src/utils/zeroWidthToUsername.js
@@ -1,5 +1,5 @@
 const zeroWidthToBinary = string => (
-  string.split('').map((char) => { // invisible &#65279;
+  string.split('﻿').map((char) => { // invisible &#65279;
     if (char === '​') { // invisible &#8203;
       return '1';
     } else if (char === '‌') { // invisible &#8204;


### PR DESCRIPTION
those two function supposed to use zero-width no-break space (\uFEFF)

but it's actually an empty text. you can tested by copy from code and paste in console

`''.length === 0` (from old code) 
`'﻿'.length === 1 && '﻿' === '\uFEFF'` (what it's supposed to be)